### PR TITLE
Multi-Pages and compatibility new JUCE

### DIFF
--- a/Source/AppsPageComponent.cpp
+++ b/Source/AppsPageComponent.cpp
@@ -41,12 +41,23 @@ AppListComponent::AppListComponent() :
 {
   addChildComponent(nextPageBtn);
   addChildComponent(prevPageBtn);
-  nextPageBtn->addListener(this);
-  prevPageBtn->addListener(this);
+  NavigationListener* list = new NavigationListener(nextPageBtn, this);
+  nextPageBtn->addListener(list);
+  prevPageBtn->addListener(list);
   
   addAndMakeVisible(grid);
 }
 AppListComponent::~AppListComponent() {}
+
+void AppListComponent::next(){
+    grid->showNextPage();
+    checkShowPageNav();
+}
+
+void AppListComponent::previous(){
+    grid->showPrevPage();
+    checkShowPageNav();
+}
 
 DrawableButton *AppListComponent::createAndOwnIcon(const String &name, const String &iconPath, const String &shell) {
   auto image = createImageFromFile(assetFile(iconPath));
@@ -278,4 +289,11 @@ void AppsPageComponent::buttonClicked(Button *button) {
     auto appButton = (AppIconButton*)button;
     startOrFocusApp(appButton);
   }
+}
+
+NavigationListener::NavigationListener(Button* next, AppListComponent* p): next(next), page(p){}
+
+void NavigationListener::buttonClicked(Button *button){
+    if(button==next) page->next();
+    else page->previous();
 }

--- a/Source/AppsPageComponent.h
+++ b/Source/AppsPageComponent.h
@@ -47,6 +47,9 @@ public:
   void resized() override;
   void checkShowPageNav();
   
+  void next();
+  void previous();
+  
   void addAndOwnIcon(const String &name, Component *icon);
   DrawableButton *createAndOwnIcon(const String &name, const String &iconPath, const String &shell);
   virtual Array<DrawableButton *> createIconsFromJsonArray(const var &json);
@@ -93,4 +96,14 @@ private:
   void openAppsLibrary();
   
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AppsPageComponent)
+};
+
+class NavigationListener : public Button::Listener {
+public:
+    NavigationListener(Button*, AppListComponent*);
+    void buttonClicked(Button *button) override;
+
+private:
+    Button* next;
+    AppListComponent* page;
 };

--- a/Source/PageStackComponent.cpp
+++ b/Source/PageStackComponent.cpp
@@ -10,7 +10,7 @@ PageStackComponent::~PageStackComponent() {}
 void PageStackComponent::paint(Graphics &g) {}
 
 void PageStackComponent::resized() {
-  if (!stack.empty()) {
+  if (!stack.isEmpty()) {
     stack.getLast()->setBounds(getBounds());
   }
 }
@@ -21,7 +21,7 @@ int PageStackComponent::getDepth() const {
 
 void PageStackComponent::pushPage(Component *page, Transition transition) {
   auto bounds = getLocalBounds();
-  if (!stack.empty()) {
+  if (!stack.isEmpty()) {
     transitionOut(stack.getLast(), transition, transitionDurationMillis);
   }
   stack.add(page);
@@ -29,7 +29,7 @@ void PageStackComponent::pushPage(Component *page, Transition transition) {
 }
 
 void PageStackComponent::swapPage(Component *page, Transition transition) {
-  if (!stack.empty()) {
+  if (!stack.isEmpty()) {
     transitionOut(stack.getLast(), transition, transitionDurationMillis);
     stack.removeLast();
   }
@@ -38,10 +38,10 @@ void PageStackComponent::swapPage(Component *page, Transition transition) {
 }
 
 void PageStackComponent::popPage(Transition transition) {
-  if (!stack.empty()) {
+  if (!stack.isEmpty()) {
     transitionOut(stack.getLast(), transition, transitionDurationMillis, true);
     stack.removeLast();
-    if (!stack.empty()) {
+    if (!stack.isEmpty()) {
       transitionIn(stack.getLast(), transition, transitionDurationMillis, true);
     }
   }
@@ -56,7 +56,7 @@ void PageStackComponent::removePage(int idx) {
 }
 
 void PageStackComponent::clear(Transition transition) {
-  if (!stack.empty()) {
+  if (!stack.isEmpty()) {
     transitionOut(stack.getLast(), transition, transitionDurationMillis, true);
   }
   stack.clear();


### PR DESCRIPTION
Added a workaround to make multipages work (more than 6 icons) and update empty to isEmpty() in PageStackComponent.cpp, as in the newest version of JUCE, empty has been replaced by isEmpty()